### PR TITLE
Pretty print multi-line batch statements.

### DIFF
--- a/src/main/java/org/jdbcdslog/LogUtils.java
+++ b/src/main/java/org/jdbcdslog/LogUtils.java
@@ -150,21 +150,23 @@ public class LogUtils {
         if (ConfigurationParameters.inlineQueryParams) {
             if (parameters != null) {
                 for (Map<Integer, Object> p : parameters) {
-                    s.append("\n");
+                    if (s.length() > 0) {
+                        s.append("\n\t");
+                    }
                     appendSqlWithInlineIndexedParams(s, sql, p);
                 }
             }
             if (namedParameters != null) {
                 for (Map<String, Object> p : namedParameters) {
-                    s.append("\n");
+                    if (s.length() > 0) {
+                        s.append("\n\t");
+                    }
                     appendSqlWithInlineNamedParams(s, sql, p);
                 }
             }
         } else {    // display separate query parameters
             appendBatchSqlsWithSeparateParams(s, sql, parameters, namedParameters);
-
         }
-
     }
 
     protected static void appendBatchSqlsWithSeparateParams(StringBuilder s,
@@ -354,8 +356,6 @@ public class LogUtils {
         for (int i = start; i < textLength; i++) {
             buf.append(text.charAt(i));
         }
-        String result = buf.toString();
-
-        return result;
+        return buf.toString();
     }
 }

--- a/src/main/java/org/jdbcdslog/StatementLoggingHandler.java
+++ b/src/main/java/org/jdbcdslog/StatementLoggingHandler.java
@@ -36,9 +36,9 @@ public class StatementLoggingHandler extends StatementLoggingHandlerTemplate<Sta
     protected void doAddBatch(Object proxy, Method method, Object[] args) {
         if (this.batchStatements == null) {
             this.batchStatements = new StringBuilder();
+        } else {
+            this.batchStatements.append("\n\t");
         }
-
-        this.batchStatements.append("\n");
         appendStatement(batchStatements, proxy, method, args);
         this.batchStatements.append(';');
 


### PR DESCRIPTION
Splitting off from PR #13.

You mentioned: 

> for the single/multi line handling, I was intentionally tried to minimize string construction in order to minimize unnecessary performance loss, for which the new way seems having a bit bigger overhead.

I changed it so that there's no extra string creation.
