### PR TITLE
Fix potential NPE

### DIFF
--- a/src/main/java/org/jdbcdslog/StatementLoggingHandler.java
+++ b/src/main/java/org/jdbcdslog/StatementLoggingHandler.java
@@ -14,11 +14,9 @@ import java.util.Set;
 public class StatementLoggingHandler extends StatementLoggingHandlerTemplate<Statement> {
     protected final static Set<String> EXECUTE_METHODS = new HashSet<String>(Arrays.asList("addBatch", "execute", "executeQuery", "executeUpdate", "executeBatch"));
     protected StringBuilder batchStatements = null;
-    protected LogMetaData logMetaData;
 
     public StatementLoggingHandler(LogMetaData logMetaData, Statement statement) {
-        super(statement);
-        this.logMetaData = logMetaData;
+        super(logMetaData, statement);
     }
 
     @Override

--- a/src/main/java/org/jdbcdslog/StatementLoggingHandlerTemplate.java
+++ b/src/main/java/org/jdbcdslog/StatementLoggingHandlerTemplate.java
@@ -19,10 +19,6 @@ import org.slf4j.Logger;
 public abstract class StatementLoggingHandlerTemplate<T extends Statement> extends LoggingHandlerSupport<T> {
     protected LogMetaData logMetaData;
 
-    public StatementLoggingHandlerTemplate(T target) {
-        super(target);
-    }
-
     public StatementLoggingHandlerTemplate(LogMetaData logMetaData, T target) {
         super(target);
         this.logMetaData = logMetaData;


### PR DESCRIPTION
StatementLoggingHandler overrides logMetaData in parent class, leaving logMetaData in StatementLoggingHandlerTemplate always null.

This is a major problem for me because I need logMetadata in StatementLoggingHandlerTemplate.
